### PR TITLE
Do not include fully qualified type info

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -31,7 +31,7 @@ for geom in (MultiPolygon, MultiLineString, MultiPoint,
              Polygon, LineString, Point)
     @eval begin
         function geojson2dict(obj::$geom)
-            dict = @compat Dict("type" => string($geom),
+            dict = @compat Dict("type" => string($(geom).name.name),
                                 "coordinates" => coordinates(obj))
             hasbbox(obj) && (dict["bbox"] = bbox(obj))
             hascrs(obj) && (dict["crs"] = crs(obj))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -348,3 +348,20 @@ feature = obj.features[1]
 @fact length(feature.geometry.coordinates) --> 1
 @fact length(feature.geometry.coordinates[1]) --> 38
 @fact feature.geometry.coordinates[1][1] --> feature.geometry.coordinates[1][end]
+
+# Tests added for PR #19
+v = Vector{Float64}[]
+push!(v, [1.0;2.0])
+push!(v, [3.0;4.0])
+ls = LineString(v)
+f = Feature(ls)
+fc = FeatureCollection(Feature[f])
+gj = GeoJSON.geojson2dict(ls)
+fj = GeoJSON.geojson2dict(f)
+fcj = GeoJSON.geojson2dict(fc)
+@fact gj["type"] --> "LineString"
+@fact fj["type"] --> "Feature"
+@fact fj["geometry"]["type"] --> "LineString"
+@fact fcj["type"] --> "FeatureCollection"
+@fact fcj["features"][1]["type"] --> "Feature"
+@fact fcj["features"][1]["geometry"]["type"] --> "LineString"


### PR DESCRIPTION
In order to create a valid GeoJSON file that can be used from Javascript libraries like d3, the GeoJSON objects included within the Dict created by geojson2dict (and hence included in the JSON objects themselves), cannot have the fully qualified Julia type information.  Prior to this commit, when using Julia 0.4.5, the dictionaries created via geojson2dict for any GeoJSON object included the fully qualified type information, including the GeoJSON package name.  This change ensures that only the geom entries in the tuple above are printed, but not the fully qualified type.