### PR TITLE
fix depwarn and set minimum julia version to 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
     - linux
 julia:
     - 0.4
+    - 0.5
     - nightly
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 os:
     - linux
 julia:
-    - 0.3
     - 0.4
     - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.4
 JSON
 Compat

--- a/src/GeoJSON.jl
+++ b/src/GeoJSON.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module GeoJSON
 
     using JSON, Compat

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1,7 +1,7 @@
 # Dict -> GeoJSON
 
 function dict2geojson(obj::Dict)
-    t = symbol(obj["type"])
+    t = Symbol(obj["type"])
     if t == :FeatureCollection
         return FeatureCollection(obj)
     elseif t == :Feature

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -23,7 +23,7 @@ function dict2geojson(obj::Dict)
     end
 end
 
-dict2geojson(obj::@compat(Void)) = obj
+dict2geojson(obj::Void) = obj
 
 # GeoJSON -> Dict
 
@@ -31,8 +31,8 @@ for geom in (MultiPolygon, MultiLineString, MultiPoint,
              Polygon, LineString, Point)
     @eval begin
         function geojson2dict(obj::$geom)
-            dict = @compat Dict("type" => string($(geom).name.name),
-                                "coordinates" => coordinates(obj))
+            dict = Dict("type" => string($(geom).name.name),
+                                  "coordinates" => coordinates(obj))
             hasbbox(obj) && (dict["bbox"] = bbox(obj))
             hascrs(obj) && (dict["crs"] = crs(obj))
             dict
@@ -41,17 +41,17 @@ for geom in (MultiPolygon, MultiLineString, MultiPoint,
 end
 
 function geojson2dict(obj::GeometryCollection)
-    dict = @compat Dict("type" => "GeometryCollection",
-                        "geometries" => map(geojson2dict, geometries(obj)))
+    dict = Dict("type" => "GeometryCollection",
+                          "geometries" => map(geojson2dict, geometries(obj)))
     hasbbox(obj) && (dict["bbox"] = bbox(obj))
     hascrs(obj) && (dict["crs"] = crs(obj))
     dict
 end
 
 function geojson2dict(obj::Feature)
-    dict = @compat Dict("type" => "Feature",
-                        "properties" => properties(obj),
-                        "geometry" => geojson2dict(geometry(obj)))
+    dict = Dict("type" => "Feature",
+                          "properties" => properties(obj),
+                          "geometry" => geojson2dict(geometry(obj)))
     hasbbox(obj) && (dict["bbox"] = bbox(obj))
     hascrs(obj) && (dict["crs"] = crs(obj))
     hasid(obj) && (dict["id"] = id(obj))
@@ -59,19 +59,19 @@ function geojson2dict(obj::Feature)
 end
 
 function geojson2dict(obj::FeatureCollection)
-    dict = @compat Dict("type" => "FeatureCollection",
-                        "features" => map(geojson2dict, features(obj)))
+    dict = Dict("type" => "FeatureCollection",
+                          "features" => map(geojson2dict, features(obj)))
     hasbbox(obj) && (dict["bbox"] = bbox(obj))
     hascrs(obj) && (dict["crs"] = crs(obj))
     dict
 end
 
-geojson2dict(obj::@compat(Void)) = obj
+geojson2dict(obj::Void) = obj
 
-# @compat(AbstractString)/File -> GeoJSON
+# String/File -> GeoJSON
 parse(input; kwargs...) = dict2geojson(JSON.parse(input; kwargs...))
 parsefile(filename; kwargs...) = dict2geojson(JSON.parsefile(filename; kwargs...))
 
-# GeoJSON -> @compat(AbstractString)/IO
+# GeoJSON -> String/IO
 geojson(obj::AbstractGeoJSON) = JSON.json(geojson2dict(obj))
 print(io::IO, obj::AbstractGeoJSON) = JSON.print(io, geojson2dict(obj))

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,7 +3,7 @@
 
 # Coordinate Reference System Objects
 # (has keys "type" and "properties")
-typealias CRS @compat(Union{Void, Dict})
+typealias CRS Union{Void, Dict}
 # TODO: Handle full CRS spec
 
 # Position
@@ -93,16 +93,16 @@ end
 # Feature Objects
 
 type Feature <: AbstractGeoJSON
-    geometry::@compat(Union{Void, Geometry})
-    properties::@compat(Union{Void, Dict})
+    geometry::Union{Void, Geometry}
+    properties::Union{Void, Dict}
     # optional
     bbox::Vector{Float64}
     crs::CRS
     id
 
     Feature(
-            geometry::@compat(Union{Void, Geometry})=nothing,
-            properties::@compat(Union{Void, Dict})=nothing;
+            geometry::Union{Void, Geometry}=nothing,
+            properties::Union{Void, Dict}=nothing;
             kwargs...
         ) =
         fill_options!(new(geometry, properties); kwargs...)
@@ -121,7 +121,7 @@ end
 
 # Helper Functions
 
-function fill_options!(obj::AbstractGeoJSON, param::@compat(AbstractString), value)
+function fill_options!(obj::AbstractGeoJSON, param::AbstractString, value)
     if param == "id"
         obj.id = value
     elseif param == "bbox"


### PR DESCRIPTION
Started off by fixing a deprecation warning, a single `symbol` -> `Symbol`. Noticed this failed tests on 0.3 so I proceeded to set the minimum version to 0.4.

If 0.3 is still needed I can also just use `@compat Symbol(...)`. But this cleans up as well.