### PR TITLE
updating TOMLs and YAMLs before release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.1
-  - 1.2
+  - 1
   - nightly
 notifications:
   email: false
@@ -14,7 +13,7 @@ coveralls: true
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.2
+      julia: 1.3
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.instantiate();

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,16 @@
 name = "GeoJSON"
 uuid = "61d90e0f-e114-555e-ac52-39dfb47a3ef9"
+license = "MIT"
+version = "0.5.0"
 
 [deps]
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [compat]
-GeoInterface = "≥ 0.4.0"
-JSON3 = "≥ 0.1.5"
-julia = "≥ 1.0.0"
+GeoInterface = "0.4, 0.5"
+JSON3 = "0.1.5"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,16 @@
 environment:
   matrix:
   - julia_version: 1.0
+  - julia_version: 1
   - julia_version: nightly
 
 platform:
   - x86 # 32-bit
   - x64 # 64-bit
 
-# # Uncomment the following lines to allow failures on nightly julia
-# # (tests will run but not make your overall status red)
-# matrix:
-#   allow_failures:
-#   - julia_version: nightly
+matrix:
+  allow_failures:
+  - julia_version: nightly
 
 branches:
   only:

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [compat]
-Documenter = "~0.23"
+Documenter = "~0.24"


### PR DESCRIPTION
It's been a while since the last release, v0.4. Master is working fine and has documentation: #19, and made the breaking change to go from JSON to JSON3: #22. Deprecation warnings are in place though.