### PR TITLE
handle missing properties with get

### DIFF
--- a/src/features.jl
+++ b/src/features.jl
@@ -43,7 +43,7 @@ function Base.getproperty(f::Feature, nm::Symbol)
         geometry(f)
     else
         props = properties(f)
-        getproperty(props, nm)
+        get(props, nm, nothing)
     end
     return ifelse(x === nothing, missing, x)
 end


### PR DESCRIPTION
@visr am @jaakkor2 this seems to be an easy solution to #45 

We just use `get` instead of `getproperty` (which JSON3 does anyway underneath) and return `missing` if a field doesn't exist.

This means we miss additional fields that are not included in the first object but are in later objects. But as a first pass it's a pretty simple solution.

For the next step I can think of two alternatives: read the property names of all fields or allow user input with a keyword argument.


(also @visr overpass turbo returns json like this, so it's definitely a common thing in the wild)