### PR TITLE
adapt name search from JSONTables.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,8 +23,9 @@ julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Plots", "Test"]
+test = ["Aqua", "DataFrames", "Plots", "Test"]

--- a/src/GeoJSON.jl
+++ b/src/GeoJSON.jl
@@ -6,7 +6,7 @@ module GeoJSON
     Base.read(path, String)
 end GeoJSON
 
-import JSON3, Tables, GeoFormatTypes, Extents, GeoInterfaceRecipes
+import Extents, GeoFormatTypes, GeoInterfaceRecipes, JSON3, JSONTables, Tables 
 import GeoInterface as GI
 
 include("geometries.jl")

--- a/src/GeoJSON.jl
+++ b/src/GeoJSON.jl
@@ -6,7 +6,7 @@ module GeoJSON
     Base.read(path, String)
 end GeoJSON
 
-import Extents, GeoFormatTypes, GeoInterfaceRecipes, JSON3, JSONTables, Tables 
+import Extents, GeoFormatTypes, GeoInterfaceRecipes, JSON3, Tables 
 import GeoInterface as GI
 
 include("geometries.jl")

--- a/src/features.jl
+++ b/src/features.jl
@@ -83,10 +83,10 @@ struct FeatureCollection{T,O,A} <: AbstractVector{T}
 end
 function FeatureCollection(object::O) where O
     features = object.features
-    if isempty(features) 
+    if isempty(features)
         names = Symbol[:geometry]
         types = Dict{Symbol,Type}(:geometry => Union{Missing,Geometry})
-        T = Feature{Any} 
+        T = Feature{Any}
     else
         names, types = property_schema(features)
         insert!(names, 1, :geometry)
@@ -97,7 +97,7 @@ function FeatureCollection(object::O) where O
         elseif f1 isa NamedTuple && isconcretetype(eltype(features))
             typeof(Feature(f1, names))
         else
-            T = Feature{Any} 
+            T = Feature{Any}
         end
     end
     return FeatureCollection{T,O,typeof(features)}(object, features, names, types)
@@ -197,7 +197,7 @@ bbox(x::GeoJSONObject) = get(object(x), :bbox, nothing)
 Base.show(io::IO, ::MIME"text/plain", x::GeoJSONObject) = show(io, x)
 
 # Adapted from JSONTables.jl jsontable method
-# We can simply use their method as we need the key/valu pairs
+# We cannot simply use their method as we need the key/value pairs
 # of the properties field, rather than the main object
 function property_schema(features)
     # Short cut for concrete eltypes of NamedTuple

--- a/src/features.jl
+++ b/src/features.jl
@@ -53,7 +53,7 @@ function Base.getproperty(f::Feature, nm::Symbol)
         if hasproperty(props, nm)
             getproperty(props, nm)
         else
-            if nm in object.parent_properties
+            if nm in getfield(f, :parent_properties)
                 missing
             else
                 error("property `$nm` is not part of Feature or parent FeatureCollection")

--- a/src/features.jl
+++ b/src/features.jl
@@ -24,8 +24,7 @@ Feature(geometry::Geometry; kwargs...) =
 Access the properties JSON object of a Feature
 """
 properties(obj::JSON3.Object) = obj.properties
-properties(f::Feature{<:JSON3.Object}) = object(f).properties
-properties(f::Feature) = haskey(object(f), :properties) ? object(f).properties : nothing
+properties(f::Feature) = object(f).properties
 
 """
     geometry(f::Feature)

--- a/src/features.jl
+++ b/src/features.jl
@@ -213,11 +213,7 @@ function property_schema(features)
     seen = Set{Symbol}()
     types = Dict{Symbol, Type}()
     for feature in features
-        props = if features isa JSON3.Array
-            feature.properties
-        else
-            properties(feature)
-        end
+        props = properties(feature)
         isnothing(props) && continue
         if isempty(names)
             for k in propertynames(props)
@@ -250,8 +246,6 @@ function property_schema(features)
     end
     return names, types
 end
-
-# Handle JSON where the properties are always in .properties
 
 missT(::Type{Nothing}) = Missing
 missT(::Type{T}) where {T} = T

--- a/src/json.jl
+++ b/src/json.jl
@@ -91,7 +91,7 @@ end
 Convert a GeoJSON geometry from JSON style object to a struct specific
 to that geometry type.
 """
-function geometry(g)
+function geometry(g::JSON3.Object)
     t = type(g)
     if t == "Point"
         Point(g)

--- a/test/geojson_samples.jl
+++ b/test/geojson_samples.jl
@@ -348,7 +348,7 @@ table_not_present = """{
     "type":"FeatureCollection",
     "features":[
         {"type":"Feature","properties":{"a":1,"b":null,"c":"only-here"},"geometry":null},
-        {"type":"Feature","properties":{"a":null,"b":null},"geometry":null},
+        {"type":"Feature","properties":{"a":null,"b":null,"d":"appears-later"},"geometry":null},
         {"type":"Feature","properties":{"a":3,"b":null},"geometry":null}
 ]}"""
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using JSON3
 using Tables
 using Test
 using Plots
+using DataFrames
 
 # samples and collections thereof defined under module T
 include("geojson_samples.jl")
@@ -113,7 +114,7 @@ include("geojson_samples.jl")
         # FeatureCollection
         features = [f]
         fc = GeoJSON.FeatureCollection(features)
-        @test GeoJSON.features(fc) === features
+        @test GeoJSON.features(fc) == features
         @test propertynames(fc) == Tables.columnnames(fc) == [:geometry, :a, :b]
         @test GeoJSON.geometry.(fc) == [p]
         @test iterate(p) === (1.1, 2)
@@ -125,6 +126,10 @@ include("geojson_samples.jl")
               DataFrame([GeoJSON.Feature((geometry = p, properties = (a = 1, geometry = "g", b = 2)))]) ==
               DataFrame(GeoJSON.FeatureCollection((type="FeatureCollection", features=[f]))) ==
               DataFrame(GeoJSON.FeatureCollection(; features))
+
+        # Mixed name vector
+        f2 = GeoJSON.Feature(p; properties = (a = 1, geometry = "g", b = 2, c = 3))
+        GeoJSON.FeatureCollection((type = "FeatureCollection", features = [f, f2]))
     end
 
     @testset "extent" begin
@@ -247,8 +252,8 @@ include("geojson_samples.jl")
         # They have to be explicitly set to null.
         # We could support it by having getproperty(f::Feature, :not_present) return missing
         # if needed, but then you always get missing instead of KeyError.
-        @test_throws KeyError t.c
-        @test_throws KeyError Tables.columntable(t)
+        # @test_throws KeyError t.c
+        # @test_throws KeyError Tables.columntable(t)
     end
 
     @testset "FeatureCollection of one GeometryCollection" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,17 +114,17 @@ include("geojson_samples.jl")
         features = [f]
         fc = GeoJSON.FeatureCollection(features)
         @test GeoJSON.features(fc) === features
-        @test propertynames(fc) === Tables.columnnames(fc) === (:geometry, :a, :b)
+        @test propertynames(fc) == Tables.columnnames(fc) == [:geometry, :a, :b]
         @test GeoJSON.geometry.(fc) == [p]
         @test iterate(p) === (1.1, 2)
         @test iterate(p, 2) === (2.2, 3)
         @test iterate(p, 3) === nothing
 
         # other constructors
-        GeoJSON.Feature(geometry = p, properties = (a = 1, geometry = "g", b = 2))
-        GeoJSON.Feature((geometry = p, properties = (a = 1, geometry = "g", b = 2)))
-        GeoJSON.FeatureCollection(; features)
-        GeoJSON.FeatureCollection((type = "FeatureCollection", features = [f]))
+        @test DataFrame([GeoJSON.Feature(geometry = p, properties = (a = 1, geometry = "g", b = 2))]) ==
+              DataFrame([GeoJSON.Feature((geometry = p, properties = (a = 1, geometry = "g", b = 2)))]) ==
+              DataFrame(GeoJSON.FeatureCollection((type="FeatureCollection", features=[f]))) ==
+              DataFrame(GeoJSON.FeatureCollection(; features))
     end
 
     @testset "extent" begin
@@ -240,8 +240,8 @@ include("geojson_samples.jl")
         @test Tables.columntable(t) isa NamedTuple
 
         t = GeoJSON.read(T.table_not_present)
-        @test propertynames(t) === propertynames(t[1]) === (:geometry, :a, :b, :c)
-        @test propertynames(t[2]) === (:geometry, :a, :b)
+        @test propertynames(t) == collect(propertynames(t[1])) == [:geometry, :a, :b, :c]
+        @test propertynames(t[2]) == (:geometry, :a, :b)
         # "c" is only present in the properyies of the first row
         # We don't support automatically setting these to missing in the tables interface.
         # They have to be explicitly set to null.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -245,7 +245,9 @@ include("geojson_samples.jl")
         @test Tables.columntable(t) isa NamedTuple
 
         t = GeoJSON.read(T.table_not_present)
-        @test propertynames(t) == collect(propertynames(t[1])) == [:geometry, :a, :b, :c, :d]
+        t[1]
+        @test propertynames(t) == [:geometry, :a, :b, :c, :d]
+        @test propertynames(t[1]) == (:geometry, :a, :b, :c)
         @test propertynames(t[2]) == (:geometry, :a, :b, :d)
         # "c" and "d" are only present in the properties of a single row
         @test all(t.c .=== ["only-here", missing, missing])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -248,12 +248,7 @@ include("geojson_samples.jl")
         @test propertynames(t) == collect(propertynames(t[1])) == [:geometry, :a, :b, :c]
         @test propertynames(t[2]) == (:geometry, :a, :b)
         # "c" is only present in the properyies of the first row
-        # We don't support automatically setting these to missing in the tables interface.
-        # They have to be explicitly set to null.
-        # We could support it by having getproperty(f::Feature, :not_present) return missing
-        # if needed, but then you always get missing instead of KeyError.
-        # @test_throws KeyError t.c
-        # @test_throws KeyError Tables.columntable(t)
+        @test all(t.c .=== ["only-here", missing, missing])
     end
 
     @testset "FeatureCollection of one GeometryCollection" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,6 +209,16 @@ include("geojson_samples.jl")
         @test geom[1][1][3] == [-117.912919, 33.96445]
         @test geom[1][1][4] == [-117.913883, 33.96657]
 
+        @testset "With NamedTuple feature" begin
+            nt_feature = GeoJSON.Feature(; 
+                geometry=t[1].geometry, 
+                properties=(cartodb_id=t[1].cartodb_id, addr1=t[1].addr1, addr2=t[1].addr2, park=t[1].park),
+            )
+            fc = GeoJSON.FeatureCollection([nt_feature])
+            @test fc isa GeoJSON.FeatureCollection
+            @test occursin("(:geometry, :cartodb_id, :addr1, :addr2, :park)", sprint(show, MIME"text/plain"(), fc[1]))
+        end
+
         @testset "write to disk" begin
             fc = t
             GeoJSON.write("test.json", fc)
@@ -264,8 +274,9 @@ include("geojson_samples.jl")
             features = map(t.geometry, nt_props) do geometry, properties
                 GeoJSON.Feature(; geometry, properties)
             end
-            @test occursin("(:geometry, :a, :b, :c)", sprint(show, MIME"text/plain"(), t[1]))
-            @test GeoJSON.FeatureCollection(features) isa GeoJSON.FeatureCollection
+            fc =  GeoJSON.FeatureCollection(features)
+            @test fc isa GeoJSON.FeatureCollection
+            @test occursin("(:geometry, :a, :b, :c)", sprint(show, MIME"text/plain"(), fc[1]))
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -245,10 +245,11 @@ include("geojson_samples.jl")
         @test Tables.columntable(t) isa NamedTuple
 
         t = GeoJSON.read(T.table_not_present)
-        @test propertynames(t) == collect(propertynames(t[1])) == [:geometry, :a, :b, :c]
-        @test propertynames(t[2]) == (:geometry, :a, :b)
-        # "c" is only present in the properyies of the first row
+        @test propertynames(t) == collect(propertynames(t[1])) == [:geometry, :a, :b, :c, :d]
+        @test propertynames(t[2]) == (:geometry, :a, :b, :d)
+        # "c" and "d" are only present in the properties of a single row
         @test all(t.c .=== ["only-here", missing, missing])
+        @test all(t.d .=== [missing, "appears-later", missing])
     end
 
     @testset "FeatureCollection of one GeometryCollection" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,7 +178,7 @@ include("geojson_samples.jl")
             <:JSON3.Object,
             <:JSON3.Array,
         }
-        @test propertynames(t) == (:geometry, :park, :cartodb_id, :addr1, :addr2)
+        @test propertynames(t) == [:geometry, :cartodb_id, :addr1, :addr2, :park]
         @test Tables.rowtable(t) isa Vector{<:NamedTuple}
         @test Tables.columntable(t) isa NamedTuple
         @inferred first(t)


### PR DESCRIPTION
Use the JSONTables.jl methods of getting a list of column names and types. Unfortunately we cant just use their methods as we need to dig into the `properties` field of each object, rather than using the top level fields.

~~@visr this isn't quite finished, just pushing so you know I'm working on it and we don't duplicate efforts~~

So it turned out to be quite tricky getting this to work for both Object and NameTuple features.

There are likely still some issues with vectors of mixed field `NamedTuple` in broadcast or other places, but mostly things seem to be working. 

See #48
Fixes #45