### PR TITLE
parse all numbers as Float64 when reading JSON

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Extents = "0.1"
 GeoFormatTypes = "0.4"
 GeoInterface = "1"
 GeoInterfaceRecipes = "1"
-JSON3 = "1"
+JSON3 = "1.12"
 Tables = "1"
 julia = "1.6"
 

--- a/src/json.jl
+++ b/src/json.jl
@@ -5,7 +5,7 @@
 Read a GeoJSON string to a GeoInterface.jl compatible feature or geometry object.
 """
 function read(source)
-    object = JSON3.read(source)
+    object = JSON3.read(source; numbertype = Float64)
     if object === nothing
         error("JSON string is empty")
     end

--- a/test/geojson_samples.jl
+++ b/test/geojson_samples.jl
@@ -487,6 +487,8 @@ geom_collection = """{
     }]
 }"""
 
-geometries = [multi, bbox, bbox_z, bermuda_triangle, geom_collection]
+point_int = """{"type":"Point","coordinates":[1,2]}"""
+
+geometries = [multi, bbox, bbox_z, bermuda_triangle, geom_collection, point_int]
 
 end  # module test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -234,7 +234,7 @@ include("geojson_samples.jl")
         @test t[1] isa GeoJSON.Feature
         @test t.geometry isa Vector{Union{T,Missing}} where {T<:GeoJSON.Point}
         @test ismissing(t.geometry[3])
-        @test t.a isa Vector{Union{Int,Missing}}
+        @test t.a isa Vector{Union{Float64,Missing}}
         @test isequal(t.a, [1, missing, 3])
         @test t.b isa Vector{Missing}
         @test Tables.columntable(t) isa NamedTuple
@@ -278,6 +278,17 @@ include("geojson_samples.jl")
         gft_dict = GeoFormatTypes.GeoJSON(dict)
         p = GeoJSON.read(gft_dict)
         @test p isa GeoJSON.Point
+    end
+
+    @testset "numbertype" begin
+        # all numbers are Float64 since we use numbertype=Float64
+        p = GeoJSON.read(T.point_int)
+        @test p isa GeoJSON.Point
+        coords = GeoJSON.coordinates(p)
+        @test coords isa JSON3.Array
+        @test eltype(coords) == Float64
+        @test coords == [1, 2]
+        @test copy(coords) isa Vector{Float64}
     end
 
     Aqua.test_all(GeoJSON)


### PR DESCRIPTION
This will avoid problems with coordinates like 1 or 1.0 being converted to Int. This also affects the properties, so integer columns will now be Float64, and will need to be manually converted to integer types.

This is now possible in the latest JSON3 release with PR https://github.com/quinnj/JSON3.jl/pull/240.
Fixes #52, also cc @jeremiahpslewis who ran into issues with this for GeoMakie.

Due to the effect on properties this should probably be released as a breaking change.