### PR TITLE
fix point order using x/y/z/m rather than getcoord

### DIFF
--- a/src/json.jl
+++ b/src/json.jl
@@ -61,7 +61,17 @@ function _lower(obj)
         nothing
     end
 end
-_lower(::GI.AbstractPointTrait, obj) = (type = "Point", coordinates = GI.coordinates(obj))
+function _lower(::GI.AbstractPointTrait, obj)
+    if GI.is3d(obj) && GI.ismeasured(obj)
+        (type = "Point", coordinates = (GI.x(obj), GI.y(obj), GI.z(obj), GI.m(obj)))
+    elseif GI.is3d(obj)
+        (type = "Point", coordinates = (GI.x(obj), GI.y(obj), GI.z(obj)))
+    elseif GI.ismeasured(obj)
+        (type = "Point", coordinates = (GI.x(obj), GI.y(obj), GI.m(obj)))
+    else
+        (type = "Point", coordinates = (GI.x(obj), GI.y(obj)))
+    end
+end
 _lower(::GI.AbstractLineStringTrait, obj) =
     (type = "LineString", coordinates = GI.coordinates(obj))
 _lower(::GI.AbstractPolygonTrait, obj) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -320,6 +320,22 @@ include("geojson_samples.jl")
         @test copy(coords) isa Vector{Float64}
     end
 
+    @testset "NamedTuple point order doesn't matter as long as it's known" begin
+        @test GeoJSON.write((X=1.0, Y=2.0)) == 
+              GeoJSON.write((Y=2.0, X=1.0)) == 
+              "{\"type\":\"Point\",\"coordinates\":[1.0,2.0]}"
+        @test GeoJSON.write((Z=3, X=1.0, Y=2.0)) == 
+              GeoJSON.write((Y=2.0, X=1.0, Z=3)) == 
+              GeoJSON.write((Y=2.0, Z=3, X=1.0)) == 
+              GeoJSON.write((X=1.0, Z=3, Y=2.0)) == 
+              "{\"type\":\"Point\",\"coordinates\":[1.0,2.0,3]}"
+        @test GeoJSON.write((Z=3, X=1.0, Y=2.0, M=4)) == 
+              GeoJSON.write((Y=2.0, X=1.0, M=4, Z=3)) == 
+              GeoJSON.write((M=4, Y=2.0, Z=3, X=1.0)) == 
+              GeoJSON.write((X=1.0, Z=3, M=4, Y=2.0)) == 
+              "{\"type\":\"Point\",\"coordinates\":[1.0,2.0,3,4]}"
+    end
+
     Aqua.test_all(GeoJSON)
 
 end  # testset "GeoJSON"


### PR DESCRIPTION
Currently we lower points to json using `getcoord`. But `getcoord` doesn't check point order so e.g a `(Y=1, X=2)` NamedTuple will be written to JSON as `[1, 2]`, switching the axes.

This is fixed by using `GeoInterface.x` `GeoInterface.y` etc on the point. This should be fine for all points where X/Y order are is known at compile time, but will have a performance hit where it's only known at run time. 