### PR TITLE
Fix coord order and performance of `write`

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -103,7 +103,7 @@ function _add_bbox(ext::Extents.Extent, nt::NamedTuple)
     if haskey(ext, :Z)
         bbox = [ext.X[1], ext.Y[1], ext.Z[1], ext.X[2], ext.Y[2], ext.Z[2]]
     else
-        bbox = [ext.X[1], ext.Y[2], ext.X[2], ext.Y[2]]
+        bbox = [ext.X[1], ext.Y[1], ext.X[2], ext.Y[2]]
     end
     merge(nt, (; bbox))
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -94,7 +94,7 @@ function _to_vector_ntuple(::GI.PointTrait, is3d::Val{true}, geom)
 end
 function _to_vector_ntuple(::GI.AbstractGeometryTrait, is3d, geom)
     map(GI.getgeom(geom)) do child_geom
-        _to_vector_ntuple(is3d, GI.geomtrait(child_geom), child_geom) 
+        _to_vector_ntuple(GI.geomtrait(child_geom), is3d, child_geom) 
     end
 end
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -61,32 +61,49 @@ function _lower(obj)
         )
         return _add_bbox(GI.extent(obj), base)
     elseif GI.isgeometry(obj)
-        _lower(GI.geomtrait(obj), obj)
+        if GI.is3d(obj)
+            _lower(GI.geomtrait(obj), Val{true}(), obj)
+        else                                           
+            _lower(GI.geomtrait(obj), Val{false}(), obj)
+        end
     else
         # null geometry
         nothing
     end
 end
-_lower(::GI.AbstractPointTrait, obj) = (type="Point", coordinates=GI.coordinates(obj))
-_lower(::GI.AbstractLineStringTrait, obj) =
-    (type="LineString", coordinates=GI.coordinates(obj))
-_lower(::GI.AbstractPolygonTrait, obj) =
-    (type="Polygon", coordinates=GI.coordinates(obj))
-_lower(::GI.AbstractMultiPointTrait, obj) =
-    (type="MultiPoint", coordinates=GI.coordinates(obj))
-_lower(::GI.AbstractMultiLineStringTrait, obj) =
-    (type="Polygon", coordinates=GI.coordinates(obj))
-_lower(::GI.AbstractMultiPolygonTrait, obj) =
-    (type="MultiPolygon", coordinates=collect(GI.coordinates(obj)))
-_lower(::GI.AbstractGeometryCollectionTrait, obj) =
+_lower(t::GI.AbstractPointTrait, d, obj) =
+    (type="Point", coordinates=_to_vector_ntuple(t, d, obj))
+_lower(t::GI.AbstractLineStringTrait, d, obj) =
+    (type="LineString", coordinates=_to_vector_ntuple(t, d, obj))
+_lower(t::GI.AbstractPolygonTrait, d, obj) =
+    (type="Polygon", coordinates=_to_vector_ntuple(t, d, obj))
+_lower(t::GI.AbstractMultiPointTrait, d, obj) =
+    (type="MultiPoint", coordinates=_to_vector_ntuple(t, d, obj))
+_lower(t::GI.AbstractMultiLineStringTrait, d, obj) =
+    (type="Polygon", coordinates=_to_vector_ntuple(t, d, obj))
+_lower(t::GI.AbstractMultiPolygonTrait, d, obj) =
+    (type="MultiPolygon", coordinates=_to_vector_ntuple(t, d, obj))
+_lower(t::GI.AbstractGeometryCollectionTrait, d, obj) =
     (type="GeometryCollection", geometries=_lower.(GI.getgeom(obj)))
+
+function _to_vector_ntuple(::GI.PointTrait, is3d::Val{false}, geom)
+    (GI.x(geom), GI.y(geom))
+end
+function _to_vector_ntuple(::GI.PointTrait, is3d::Val{true}, geom)
+    (GI.x(geom), GI.y(geom), GI.z(geom))
+end
+function _to_vector_ntuple(::GI.AbstractGeometryTrait, is3d, geom)
+    map(GI.getgeom(geom)) do child_geom
+        _to_vector_ntuple(is3d, GI.geomtrait(child_geom), child_geom) 
+    end
+end
 
 _add_bbox(::Nothing, nt::NamedTuple) = nt
 function _add_bbox(ext::Extents.Extent, nt::NamedTuple)
     if haskey(ext, :Z)
         bbox = [ext.X[1], ext.Y[1], ext.Z[1], ext.X[2], ext.Y[2], ext.Z[2]]
     else
-        bbox = [ext.X[1], ext.Y[1], ext.X[2], ext.Y[2]]
+        bbox = [ext.X[1], ext.Y[2], ext.X[2], ext.Y[2]]
     end
     merge(nt, (; bbox))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -316,6 +316,23 @@ include("geojson_samples.jl")
         GeoJSON.read(Samples.null_prop_feat)
     end
 
+    @testset "NamedTuple point order doesn't matter as long as it's known" begin
+        @test GeoJSON.write((X=1.0, Y=2.0)) == 
+              GeoJSON.write((Y=2.0, X=1.0)) == 
+              "{\"type\":\"Point\",\"coordinates\":[1.0,2.0]}"
+        @test GeoJSON.write((Z=3, X=1.0, Y=2.0)) == 
+              GeoJSON.write((Y=2.0, X=1.0, Z=3)) == 
+              GeoJSON.write((Y=2.0, Z=3, X=1.0)) == 
+              GeoJSON.write((X=1.0, Z=3, Y=2.0)) == 
+              "{\"type\":\"Point\",\"coordinates\":[1.0,2.0,3]}"
+        # M is not in the spec
+        @test GeoJSON.write((Z=3, X=1.0, Y=2.0, M=4)) == 
+              GeoJSON.write((Y=2.0, X=1.0, M=4, Z=3)) == 
+              GeoJSON.write((M=4, Y=2.0, Z=3, X=1.0)) == 
+              GeoJSON.write((X=1.0, Z=3, M=4, Y=2.0)) == 
+              "{\"type\":\"Point\",\"coordinates\":[1.0,2.0,3]}"
+    end
+
     Aqua.test_all(GeoJSON)
 
 end  # testset "GeoJSON"


### PR DESCRIPTION
Similar to #57 but with the new updates.

Fixes point order to be always `X, Y, (Z)`, and uses Vectors of NTuple rather than `GI.coordinates` to reduce allocation and improve type stability.

The performance is still not amazing, I feel like we could use some kind of lazy array of NTuple to stream from geometries strait to string rather than allocating the intermediate arrays.

```julia
using GeoJSON
using BenchmarkTools
using GeometryBasics
using ArchGDAL
import GeoInterface as GI
include("geojson_samples.jl")

g = GI.geometry(GeoJSON.read(Samples.features[4]))
g1 = GI.convert(ArchGDAL, g)
g2 = GI.convert(GeometryBasics, g)
g3 = GI.convert(GI, g)

# This branch

julia> @btime GeoJSON.write($g)
  1.026 μs (13 allocations: 1.40 KiB)
"{\"type\":\"MultiLineString\",\"coordinates\":[[[3.75,9.25],[-130.95,1.52]],[[23.15,-34.25],[-1.35,-4
.65],[3.45,77.95]]]}"

julia> @btime GeoJSON.write($g1)
  3.316 μs (50 allocations: 4.82 KiB)
"{\"type\":\"Polygon\",\"coordinates\":[[[3.75,9.25],[-130.9499969482422,1.5199999809265137]],[[23.149
999618530273,-34.25],[-1.350000023841858,-4.650000095367432],[3.450000047683716,77.94999694824219]]]}"

julia> @btime GeoJSON.write($g2)
  1.435 μs (24 allocations: 4.37 KiB)
"{\"type\":\"Polygon\",\"coordinates\":[[[3.75,9.25],[-130.9499969482422,1.5199999809265137]],[[23.149
999618530273,-34.25],[-1.350000023841858,-4.650000095367432],[3.450000047683716,77.94999694824219]]]}"

julia> @btime GeoJSON.write($g3)
  1.789 μs (24 allocations: 1.51 KiB)
"{\"type\":\"Polygon\",\"coordinates\":[[[3.75,9.25],[-130.95,1.52]],[[23.15,-34.25],[-1.35,-4.65],[3.
45,77.95]]]}"

# main

julia> @btime GeoJSON.write($g)
  1.029 μs (13 allocations: 1.40 KiB)
"{\"type\":\"MultiLineString\",\"coordinates\":[[[3.75,9.25],[-130.95,1.52]],[[23.15,-34.25],[-1.35,-4
.65],[3.45,77.95]]]}"

julia> @btime GeoJSON.write($g1)
  11.873 μs (74 allocations: 5.91 KiB)
"{\"type\":\"Polygon\",\"coordinates\":[[[3.75,9.25],[-130.9499969482422,1.5199999809265137]],[[23.149
999618530273,-34.25],[-1.350000023841858,-4.650000095367432],[3.450000047683716,77.94999694824219]]]}"

julia> @btime GeoJSON.write($g2)
  2.799 μs (28 allocations: 4.59 KiB)
"{\"type\":\"Polygon\",\"coordinates\":[[[3.75,9.25],[-130.9499969482422,1.5199999809265137]],[[23.149
999618530273,-34.25],[-1.350000023841858,-4.650000095367432],[3.450000047683716,77.94999694824219]]]}"

julia> @btime GeoJSON.write($g3)
  2.253 μs (12 allocations: 1.01 KiB)
"{\"type\":\"Polygon\",\"coordinates\":[[[3.75,9.25],[-130.95,1.52]],[[23.15,-34.25],[-1.35,-4.65],[3.
45,77.95]]]}"
```  