### PR TITLE
Support extraction of a set of features

### DIFF
--- a/src/geojson_types.jl
+++ b/src/geojson_types.jl
@@ -265,7 +265,7 @@ Base.length(fc::AbstractFeatureCollection) = length(features(fc))
 Base.lastindex(fc::AbstractFeatureCollection) = length(features(fc))
 Base.IteratorSize(::Type{<:AbstractFeatureCollection}) = Base.HasLength()
 Base.size(fc::AbstractFeatureCollection) = size(features(fc))
-Base.getindex(fc::AbstractFeatureCollection, i::Int) = features(fc)[i]
+Base.getindex(fc::AbstractFeatureCollection, i::Union{Int,UnitRange,Vector}) = features(fc)[i]
 Base.IndexStyle(::AbstractFeatureCollection) = IndexLinear()
 
 bbox(x::GeoJSONT) = getfield(x, :bbox)


### PR DESCRIPTION
Current implementation only works when extracting a single feature from a `FeatureCollection`.

This PR includes a small change to allow multiple features to be extracted.

```julia
fc[1]
fc[1:10]
fc[[1,20,30,40,50]]
```

Closes #75