### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ GeoJSON only provides simple `read` and `write` methods.
 ```julia
 julia> using GeoJSON, DataFrames
 
-julia> fc = GeoJSON.read("path/to/a.geojson")
+julia> jsonbytes = read("path/to/a.geojson");
+2182679-element Vector{UInt8}:
+
+julia> fc = GeoJSON.read(jsonbytes)
 FeatureCollection with 171 Features
 
 julia> first(fc)


### PR DESCRIPTION
First example in ReadMe does not work. 

Initial reading of bytes required  before calling GeoJSON.read.