### PR TITLE
fix read(io) to support Downloads.download of stdlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ julia> write(fc)
 
 
 ### HTTP access
-To read JSON from a URL, use HTTP.jl
+To read JSON from a URL, use Downloads
 ```julia
 
-julia> using GeoJSON, HTTP
+julia> using GeoJSON, Downloads
 
-julia> resp = HTTP.get("https://path/to/file.json")
+julia> io = Downloads.download("https://its-live-data.s3.amazonaws.com/datacubes/catalog_v02.json", IOBuffer())
 
-julia> fc = GeoJSON.read(resp.body)
+julia> fc = GeoJSON.read(io)
 ```

--- a/src/io.jl
+++ b/src/io.jl
@@ -11,6 +11,7 @@ Read GeoJSON to a GeoInterface.jl compatible object.
 - `numbertype::DataType=Float32`: Use Float64 when the precision is required.
 """
 function read(io; lazyfc=false, ndim=2, numbertype=Float32)
+    eof(io) && seekstart(io)
     if lazyfc
         obj = JSON3.read(io, LazyFeatureCollection{ndim,numbertype})
     else


### PR DESCRIPTION
using Downloads instead of HTTP.jl
We don't need a dependency on HTTP.jl

```julia
using GeoJSON, Downloads
io = Downloads.download("https://its-live-data.s3.amazonaws.com/datacubes/catalog_v02.json", IOBuffer())
fc = GeoJSON.read(io)
```